### PR TITLE
Include 'Content-Type': 'application/json' header

### DIFF
--- a/lib/ha-api.js
+++ b/lib/ha-api.js
@@ -9,7 +9,7 @@ class HaApi {
 
         const apiOpts   = { baseURL: config.baseUrl + '/api' };
         apiOpts.headers = (config.apiPass)
-            ? { 'x-ha-access': config.apiPass }
+            ? { 'x-ha-access': config.apiPass, 'Content-Type': 'application/json' }
             : {};
 
         this.client = axios.create(apiOpts);


### PR DESCRIPTION
This was necessary to get the REST API working using a password other than 'password'. This is probably some weird HA bug but I wanted to get this working in my setup and I didn't see any harm including the headers according to their docs: https://home-assistant.io/developers/rest_api/